### PR TITLE
Aanpassingen aan pad

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,3 @@ _bookdown/
 # exe files
 *.exe
 
-# pad file
-pad.R
-

--- a/150_geintegreerd_rapport/_bookdown.yml
+++ b/150_geintegreerd_rapport/_bookdown.yml
@@ -1,4 +1,5 @@
 book_filename: "moneos_2021"
+output_dir: "."
 delete_merged_file: TRUE
 language:
   label:

--- a/pad.R
+++ b/pad.R
@@ -1,7 +1,7 @@
-
+pad_prj_schelde <- Sys.getenv("pad_prj_schelde")
 
 # pad pc joost
-pad_prj_schelde <- "G:/Mijn Drive/INBODATA/PROJECTEN/PRJ_SCHELDE/"
+# pad_prj_schelde <- "G:/Mijn Drive/INBODATA/PROJECTEN/PRJ_SCHELDE/"
 # pad citrix joost
 # basis_pad <- "//Client/G$/Mijn Drive/INBODATA/PROJECTEN/PRJ_SCHELDE/"
 

--- a/pad.R
+++ b/pad.R
@@ -1,4 +1,7 @@
 pad_prj_schelde <- Sys.getenv("pad_prj_schelde")
+if (pad_prj_schelde == "") {
+  stop("Maak een bestand .Renviron aan met het pad waar PRJ_SCHELDE staat, zie de instructies voor deze repo.")
+}
 
 # pad pc joost
 # pad_prj_schelde <- "G:/Mijn Drive/INBODATA/PROJECTEN/PRJ_SCHELDE/"

--- a/pad.R
+++ b/pad.R
@@ -2,15 +2,6 @@ pad_prj_schelde <- Sys.getenv("pad_prj_schelde")
 if (pad_prj_schelde == "") {
   stop("Maak een bestand .Renviron aan met het pad waar PRJ_SCHELDE staat, zie de instructies voor deze repo.")
 }
-
-# pad pc joost
-# pad_prj_schelde <- "G:/Mijn Drive/INBODATA/PROJECTEN/PRJ_SCHELDE/"
-# pad citrix joost
-# basis_pad <- "//Client/G$/Mijn Drive/INBODATA/PROJECTEN/PRJ_SCHELDE/"
-
-# pad pc Gunther
-# pad_prj_schelde <- "G:/Mijn Drive/PRJ_SCHELDE/"
-
 pad_moneos <- "VNSC/Rapportage_INBO/"
 pad_jaar <- "2021/"
 


### PR DESCRIPTION
Een probleem was dat iedereen een verschillend pad had en dit rechtstreeks ingelezen werd in file `pad.R`.  In commit a664f604fad50bc99d6e0ef1fc2884ea2201c29c werd dit opgelost door de hele file niet te delen, wat uiteraard niet ideaal is als er aanpassingen nodig zijn in de rest van het script, bv. de functie.

De huidige voorgestelde werkwijze is:
- iedere gebruiker slaat het path als omgevingsvariabele `pad_prj_schelde` op (in een bestand `.Renviron` in de root van de repo), en dit wordt niet gedeeld (RStudio moet herstart worden na toevoegen van deze omgevingsvariabele om deze te kunnen gebruiken)
- dit path kan opgeroepen worden met de functie `Sys.getenv("pad_prj_schelde")`
- als dit niet bestaat, wordt er een foutmelding gegeven waarin verwezen wordt naar de instructies van de repo.  Het zou eigenlijk best zijn om een readme-file aan te maken waarin alle stappen komen die uitgevoerd moeten worden om de 'werkomgeving' in orde te zetten en evt. ook hoe een hoofdstuk toegevoegd wordt, en het aanmaken van een omgevingsvariabele zou daar best bij komen

Omdat ik toch aan paths bezig ben, heb ik ook het path voor de build van het volledige rapport aangepast, zodat die `_book`-map niet meer nodig is.
fixes #4